### PR TITLE
Change logo color from blue to green

### DIFF
--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -15,7 +15,7 @@ export function Logo({ size = 48, className = "" }: LogoProps) {
     >
       <path
         d="M24 4C12.954 4 4 12.954 4 24s8.954 20 20 20 20-8.954 20-20"
-        stroke="#3B82F6"
+        stroke="#22C55E"
         strokeWidth="4"
         strokeLinecap="round"
         fill="none"


### PR DESCRIPTION
## Motivation
I needed to update the logo to use a green color scheme instead of the current blue, improving the visual branding consistency.

## Changes
- Updated the logo stroke color in `components/Logo.tsx` from blue (#3B82F6) to green (#22C55E)

## Impact
The logo now displays in green, aligning with the updated brand color scheme throughout the application.

---

[See conversation that lead to this PR](https://ariana.dev/app/access-agent?token=token_5dc2982f-ff1d-41ad-b16e-c036dfef7d7e_1764594904471&projectId=proj_b014c4ec-47c4-4296-8fcf-513e5420b439&agentId=5dc2982f-ff1d-41ad-b16e-c036dfef7d7e)